### PR TITLE
add `current_user` to jinja_values_base for convenience

### DIFF
--- a/responder_login/login_manager.py
+++ b/responder_login/login_manager.py
@@ -77,6 +77,7 @@ class LoginManager:
 
     def init_api(self, api):
         api.login_manager = self
+        api.jinja_values_base['current_user'] = self.current_user
         self._api = api
 
     def _unauthorized(self, *args, **kwargs):


### PR DESCRIPTION
Now we need to write like `api.login_manager.current_user` to get current logged in user in Jinja2 template, however, by this pull request, we can simply write `current_user`.

Notice: I didn't test this.